### PR TITLE
add a seed config to ease test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ rock.build-tests package
 set](https://github.com/rock-core/rock.build-tests-package_set). The result is
 then checked by running the test suite from `build_tests/test`, which verifies
 that everything behaved as expected.
+
+When bootstrapping, use the provided `seed-config.yml` file as seed.

--- a/seed-config.yml
+++ b/seed-config.yml
@@ -3,3 +3,4 @@ autoproj_test_utility:
   base/types: false
   orogen: false
   rtt: false
+  build_tests/rock.core/tests-build-if-enabled: false

--- a/seed-config.yml
+++ b/seed-config.yml
@@ -1,0 +1,5 @@
+autoproj_test_utility_default: true
+autoproj_test_utility:
+  base/types: false
+  orogen: false
+  rtt: false


### PR DESCRIPTION
This seed config still needs to be used manually. It is meant to configure the test facility as expected by the tests themselves.