### PR TITLE
add test for USE_BINARY_DIR in the rock CMake macros in base/cmake

### DIFF
--- a/rock.build-tests/packages.autobuild
+++ b/rock.build-tests/packages.autobuild
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 Autoproj::PackageManagers::BundlerManager
-    .add_build_configuration_for('gem_build_flags', "--with-package_set-packages=success")
+    .add_build_configuration_for('gem_build_flags', '--with-package_set-packages=success')
 
 cmake_package 'build_tests/rock.core/enable-tests'
 cmake_package 'build_tests/rock.core/tests-built-if-enabled'
@@ -31,7 +33,8 @@ orogen_package 'build_tests/orogen/use_intermediate_type_on_interface'
 orogen_package 'build_tests/orogen/m_type_generation'
 orogen_package 'build_tests/orogen/root_project'
 orogen_package 'build_tests/orogen/subclass_task_from_other_project'
-orogen_package 'build_tests/orogen/typekit_generation_with_pending_types_containing_opaques'
+orogen_package 'build_tests/orogen/'\
+               'typekit_generation_with_pending_types_containing_opaques'
 orogen_package 'build_tests/orogen/default_extensions' do |pkg|
     pkg.orogen_options << '--extensions=trigger_enabled_twice_bug'
 end

--- a/rock.build-tests/packages.autobuild
+++ b/rock.build-tests/packages.autobuild
@@ -24,6 +24,7 @@ cmake_package 'build_tests/cmake/rock_library_deps_pkgconfig'
 cmake_package 'build_tests/cmake/rock_library_no_public_dependencies'
 cmake_package 'build_tests/cmake/rock_library_make_all_dependencies_public'
 cmake_package 'build_tests/cmake/rock_library_mode'
+cmake_package 'build_tests/cmake/rock_target_setup_supports_headers_in_build_dir'
 cmake_package 'build_tests/cmake/var_ROCK_PUBLIC_CXX_STANDARD'
 
 orogen_package 'build_tests/orogen/cxx11_dependency'


### PR DESCRIPTION
Depends on:
- [x] https://github.com/rock-core/base-cmake/pull/53