### PR TITLE
Add test for package that does not call rock_standard_layout()

### DIFF
--- a/rock.build-tests/packages.autobuild
+++ b/rock.build-tests/packages.autobuild
@@ -26,6 +26,7 @@ cmake_package 'build_tests/cmake/rock_library_make_all_dependencies_public'
 cmake_package 'build_tests/cmake/rock_library_mode'
 cmake_package 'build_tests/cmake/rock_target_setup_supports_headers_in_build_dir'
 cmake_package 'build_tests/cmake/var_ROCK_PUBLIC_CXX_STANDARD'
+cmake_package 'build_tests/cmake/no_standard_layout_package'
 
 orogen_package 'build_tests/orogen/cxx11_dependency'
 orogen_package 'build_tests/orogen/ro_ptr'


### PR DESCRIPTION
Depends on:
- [x] https://github.com/rock-core/base-cmake/pull/55

Regression test for https://github.com/rock-core/base-cmake/pull/55

Supersedes https://github.com/rock-core/rock.build-tests-package_set/pull/7, since the package set is not in use anymore