### PR TITLE
add regression test for minitest-junit being added as dependency unnecessarily

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/*_test.rb"]
+  t.warning = false
 end
 
 task :default

--- a/rock.build-tests/packages.autobuild
+++ b/rock.build-tests/packages.autobuild
@@ -5,6 +5,7 @@ Autoproj::PackageManagers::BundlerManager
 
 cmake_package 'build_tests/rock.core/enable-tests'
 cmake_package 'build_tests/rock.core/tests-built-if-enabled'
+cmake_package 'build_tests/rock.core/does_not_add_minitest_junit_dependency_on_disabled_tests'
 
 import_package 'build_tests/autoproj/checkout_of_test_dependencies_make-dep'
 cmake_package 'build_tests/autoproj/checkout_of_test_dependencies_make'

--- a/seed-config.yml
+++ b/seed-config.yml
@@ -4,3 +4,4 @@ autoproj_test_utility:
   orogen: false
   rtt: false
   build_tests/rock.core/tests-build-if-enabled: false
+  build_tests/rock.core/does_not_add_minitest_junit_dependency_on_disabled_tests: false

--- a/test/rock_core_test.rb
+++ b/test/rock_core_test.rb
@@ -12,5 +12,17 @@ describe "rock.core package set configuration" do
         # workspace. Use the buildconf seed config.
         refute system("which", "rock-core-tests-built-if-enabled")
     end
+
+    it 'adds the minitest-junit dependency on CMake packages '\
+       'with Ruby bindings if the tests are enabled' do
+        output = `#{File.join(ENV['AUTOPROJ_CURRENT_ROOT'], '.autoproj', 'bin', 'autoproj')} show rock_ruby_test_writes_junit_report`
+        assert_match(/minitest-junit/, output)
+    end
+
+    it 'does not add the minitest-junit dependency on CMake packages '\
+       'with Ruby bindings if the tests are disabled' do
+        output = `#{File.join(ENV['AUTOPROJ_CURRENT_ROOT'], '.autoproj', 'bin', 'autoproj')} show does_not_add_minitest_junit_dependency_on_disabled_tests`
+        refute_match(/minitest-junit/, output)
+    end
 end
 


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/package_set/pull/164

rock.core's overrides auto-add minitest-junit to CMake packages that
have a bindings/ruby/test folder. This is a regression test to ensure
that the dependency is not added if the tests are disabled.
