### PR TITLE
add build_tests/orogen/leading_underscore

### DIFF
--- a/rock.build-tests/packages.autobuild
+++ b/rock.build-tests/packages.autobuild
@@ -35,6 +35,7 @@ cmake_package 'build_tests/cmake/rock_install_python_bindings' do |pkg|
     pkg.define 'PYTHON_EXECUTABLE', bin if bin
 end
 
+orogen_package 'build_tests/orogen/leading_underscore'
 orogen_package 'build_tests/orogen/cxx11_dependency'
 orogen_package 'build_tests/orogen/ro_ptr'
 orogen_package 'build_tests/orogen/ro_ptr_import'


### PR DESCRIPTION
Build tests for https://github.com/orocos-toolchain/orogen/issues/132

Depends on:
 - [x] https://github.com/orocos-toolchain/orogen/pull/133
 - [x] https://github.com/rock-core/build_tests-orogen-leading_underscore/pull/1