### PR TITLE
Add qt4/qt5 tests

### DIFF
--- a/rock.build-tests/packages.autobuild
+++ b/rock.build-tests/packages.autobuild
@@ -39,6 +39,8 @@ cmake_package 'build_tests/cmake/deps_target_transitive_dependency'
 cmake_package 'build_tests/cmake/deps_target'
 cmake_package 'build_tests/cmake/deps_target_use_pkgconfig'
 cmake_package 'build_tests/cmake/find_gem'
+cmake_package 'build_tests/cmake/qt4'
+cmake_package 'build_tests/cmake/qt5'
 
 orogen_package 'build_tests/orogen/leading_underscore'
 orogen_package 'build_tests/orogen/cxx11_dependency'

--- a/rock.build-tests/test.osdeps
+++ b/rock.build-tests/test.osdeps
@@ -1,0 +1,3 @@
+qt5:
+    debian, ubuntu: qt5-default
+


### PR DESCRIPTION
As required [here](https://github.com/rock-core/base-cmake/pull/72), I added test cases for qt4 and the new qt5 macro.