### PR TITLE
Add test packages and tests for c++ standard flags order

### DIFF
--- a/rock.build-tests/packages.autobuild
+++ b/rock.build-tests/packages.autobuild
@@ -72,4 +72,9 @@ orogen_package 'build_tests/orogen/global_initializer'
 orogen_package 'build_tests/orogen/opaque_with_ptr_type_generation'
 orogen_package 'build_tests/orogen/using_task_library_not_picking_up_not_directly_used_dependencies_publisher'
 orogen_package 'build_tests/orogen/using_task_library_not_picking_up_not_directly_used_dependencies_consumer'
+orogen_package 'build_tests/orogen/cxx_standards_11_then_14'
+#This requires changes to orogen and base/cmake to pass
+#https://github.com/pierrewillenbrockdfki/tools-orogen/tree/improve-handling-pc-std-flags
+#https://github.com/pierrewillenbrockdfki/base-cmake/tree/cxx-standard-to-compile-feature
+#orogen_package 'build_tests/orogen/cxx_standards_14_then_11'
 


### PR DESCRIPTION
@doudou this adds the test packages and tests for checking that the order of package dependencies does not change the resulting compile flags. Since that still is the case, the offending tests have been commented out with a comment explaining their dependencies.

This can be merged as is, with followup patches+PRs that activate the given tests, or can wait until the changes to base/cmake and orogen have been merged, with maybe a single extra commit here. The relevant PRs are: https://github.com/rock-core/base-cmake/pull/80, https://github.com/rock-core/tools-orogen/pull/11